### PR TITLE
Various Downstream Fixes - Canvas & Votes

### DIFF
--- a/js/soa.js
+++ b/js/soa.js
@@ -93,7 +93,7 @@ function removeVote(row) {
  */
 function manualVote() {
     let blankVote = {code: '', title: '', result: 'Failed', link: ''};
-    id('votes').appendChild(createTableRow(blankVote), 'V');
+    id('votes').appendChild(createTableRow(blankVote, 'V'));
     REPORT_DETAILS.votes.push(blankVote);
     updateVoteCount();
 }

--- a/js/soa.js
+++ b/js/soa.js
@@ -64,7 +64,7 @@ function loadVotes() {
             result: data[3],
             link: ''
         };
-        id('votes').appendChild(createTableRow(vote), 'V');
+        id('votes').appendChild(createTableRow(vote, 'V'));
         REPORT_DETAILS.votes.push(vote);
         updateVoteCount();
     }

--- a/js/vote-close.js
+++ b/js/vote-close.js
@@ -52,6 +52,10 @@ function generate() {
 
 // Paint a visual representation of the voting results.
 function createVisual(voteID, threshold, tally) {
+    
+    CTX.beginPath();
+    CTX.clearRect(0, 0, CTX.width, CTX.height);
+    CTX.closePath();
 
     // Draw the static background image.
     CTX.drawImage(document.getElementById('bg'), 0, 0);


### PR DESCRIPTION
This PR cherry-picks specific commits from https://github.com/The-East-Pacific/provost-tools/ that fix the following bugs:

- Generating a result image, changing the threshold and generating a new image without refreshing causes duplicate threshold bars to appear
- Vote buttons were added without the "temp" attribute being correctly applied. This resulted in the vote counter not updating correctly when votes were removed.